### PR TITLE
Added a variation of the `zipOrAccumulate` functions for error types defining a `cats.kernel.Semigroup`

### DIFF
--- a/cats-raise4s/README.md
+++ b/cats-raise4s/README.md
@@ -2,6 +2,7 @@
 <br/>
 
 # Raise4s for Cats
+
 Integration of the Raise DSL with some useful Cats data structures.
 
 ## Dependency
@@ -14,44 +15,65 @@ libraryDependencies += "in.rcard.raise4s" %% "cats-raise4s" % "0.0.6"
 
 The library is only available for Scala 3.
 
-## Usage 
+## Usage
 
 In general, the integration lets you use the _Cats_ type classes with the _Raise_ DSL. In detail:
 
-- Use the `Semigroup` type class to combine errors in the `mapOrAccumlate` function.
+- Use the `Semigroup` type class to combine errors in the `mapOrAccumlateS` function.
 
-```scala 3
-case class MyError2(errors: List[String])
-
-given Semigroup[MyError2] with {
-  def combine(error1: MyError2, error2: MyError2): MyError2 =
-    MyError2(error1.errors ++ error2.errors)
-}
-
-val block: List[Int] raises MyError2 =
-  CatsRaise.mapOrAccumulateS(List(1, 2, 3, 4, 5)) { value1 =>
-    value1 + 1
+  ```scala 3
+  case class MyError2(errors: List[String])
+  
+  given Semigroup[MyError2] with {
+    def combine(error1: MyError2, error2: MyError2): MyError2 =
+      MyError2(error1.errors ++ error2.errors)
   }
-val actual = Raise.fold(
-  block,
-  error => fail(s"An error occurred: $error"),
-  identity
-)
-actual shouldBe List(2, 3, 4, 5, 6)
-```
+  
+  val block: List[Int] raises MyError2 =
+    CatsRaise.mapOrAccumulateS(List(1, 2, 3, 4, 5)) { value1 =>
+      value1 + 1
+    }
+  val actual = Raise.fold(
+    block,
+    error => fail(s"An error occurred: $error"),
+    identity
+  )
+  actual shouldBe List(2, 3, 4, 5, 6)
+  ```
 
 - Use of the `NonEmptyList` data class to handle errors in the `mapOrAccumulate` function.
 
-```scala 3
-val block: List[Int] raises NonEmptyList[String] = Raise.mapOrAccumulate(List(1, 2, 3, 4, 5)) {
-  _ + 1
-}
+  ```scala 3
+  val block: List[Int] raises NonEmptyList[String] = Raise.mapOrAccumulate(List(1, 2, 3, 4, 5)) {
+    _ + 1
+  }
+  
+  val actual = Raise.fold(
+    block,
+    error => fail(s"An error occurred: $error"),
+    identity
+  )
+  
+  actual shouldBe List(2, 3, 4, 5, 6)
+  ```
 
-val actual = Raise.fold(
-  block,
-  error => fail(s"An error occurred: $error"),
-  identity
-)
+- Use the `Semigroup` type class to combine errors in the `zipOrAccumlateS` set of functions.
 
-actual shouldBe List(2, 3, 4, 5, 6)
-```
+  ```scala 3
+  case class MyError2(errors: List[String])
+  given Semigroup[MyError2] with {
+    def combine(error1: MyError2, error2: MyError2): MyError2 =
+      MyError2(error1.errors ++ error2.errors)
+  }
+  val block: List[Int] raises MyError2 =
+    CatsRaise.zipOrAccumulateS({ 1 }, { 2 }) {
+      case (a, b) =>
+        List(a, b)
+    }
+  val actual = Raise.fold(
+    block,
+    error => fail(s"An error occurred: $error"),
+    identity
+  )
+  actual should be(List(1, 2))
+  ```

--- a/cats-raise4s/src/main/scala/in/rcard/raise4s/cats/CatsRaise.scala
+++ b/cats-raise4s/src/main/scala/in/rcard/raise4s/cats/CatsRaise.scala
@@ -39,7 +39,7 @@ object CatsRaise {
     *   The Raise context
     * @tparam Error
     *   The type of the logical error that can be raised. It must have a [[Semigroup]] instance
-    *   available
+    *   available available
     * @tparam A
     *   The type of the elements in the `iterable`
     * @tparam B
@@ -96,4 +96,287 @@ object CatsRaise {
       )
     )
     NonEmptyList.fromList(errors.toList).fold(results.toList)(r.raise)
+
+  /** Accumulate the errors from running `action1`, `action2`, `action3`, `action4`, `action5`,
+    * `action6`, `action7`, `action8`, and `action9`, or accumulate all the occurred errors using
+    * the [[Semigroup]] type class defined on the `Error` type. The tailing `S` in the name of the
+    * function stands for <em>Semigroup</em>.
+    *
+    * <h2>Example</h2>
+    * {{{
+    * case class MyError2(errors: List[String])
+    *
+    * given Semigroup[MyError2] with {
+    *   def combine(error1: MyError2, error2: MyError2): MyError2 =
+    *     MyError2(error1.errors ++ error2.errors)
+    * }
+    *
+    * val block: List[Int] raises MyError2 =
+    *   CatsRaise.zipOrAccumulateS({ 1 }, { 2 }, { 3 }, { 4 }, { 5 }, { 6 }, { 7 }, { 8 }, { 9 }) {
+    *     case (a, b, c, d, e, f, g, h, i) =>
+    *       List(a, b, c, d, e, f, g, h, i)
+    *   }
+    * val actual = Raise.fold(
+    *   block,
+    *   error => fail(s"An error occurred: $error"),
+    *   identity
+    * )
+    * actual should be(List(1, 2, 3, 4, 5, 6, 7, 8, 9))
+    * }}}
+    *
+    * @param action1
+    *   Code block to run on type `A`
+    * @param action2
+    *   Code block to run on type `B`
+    * @param action3
+    *   Code block to run on type `C`
+    * @param action4
+    *   Code block to run on type `D`
+    * @param action5
+    *   Code block to run on type `E`
+    * @param action6
+    *   Code block to run on type `F`
+    * @param action7
+    *   Code block to run on type `G`
+    * @param action8
+    *   Code block to run on type `H`
+    * @param action9
+    *   Code block to run on type `I`
+    * @param block
+    *   Function to run on the results of the code blocks
+    * @param r
+    *   The Raise context
+    * @tparam Error
+    *   The type of the logical error that can be raised by any code block. It must have a
+    *   [[Semigroup]] instance available
+    * @tparam A
+    *   The type of the result of the first code block
+    * @tparam B
+    *   The type of the result of the second code block
+    * @tparam C
+    *   The type of the result of the third code block
+    * @tparam D
+    *   The type of the result of the fourth code block
+    * @tparam E
+    *   The type of the result of the fifth code block
+    * @tparam F
+    *   The type of the result of the sixth code block
+    * @tparam G
+    *   The type of the result of the seventh code block
+    * @tparam H
+    *   The type of the result of the eighth code block
+    * @tparam I
+    *   The type of the result of the ninth code block
+    * @tparam J
+    *   The type of the result of the block function
+    * @return
+    *   The result of the block function
+    */
+  inline def zipOrAccumulateS[Error: Semigroup, A, B, C, D, E, F, G, H, I, J](
+      inline action1: Raise[Error] ?=> A,
+      inline action2: Raise[Error] ?=> B,
+      inline action3: Raise[Error] ?=> C,
+      inline action4: Raise[Error] ?=> D,
+      inline action5: Raise[Error] ?=> E,
+      inline action6: Raise[Error] ?=> F,
+      inline action7: Raise[Error] ?=> G,
+      inline action8: Raise[Error] ?=> H,
+      inline action9: Raise[Error] ?=> I
+  )(inline block: (A, B, C, D, E, F, G, H, I) => J)(using r: Raise[Error]): J =
+    Raise.zipOrAccumulate(Semigroup[Error].combine)(
+      action1,
+      action2,
+      action3,
+      action4,
+      action5,
+      action6,
+      action7,
+      action8,
+      action9
+    )(block)
+
+    /** Accumulate the errors from running `action1`, `action2`, `action3`, `action4`, `action5`,
+      * `action6`, `action7`, and `action8`, or accumulate all the occurred errors using the
+      * [[Semigroup]] type class defined on the `Error` type. The tailing `S` in the name of the
+      * function stands for <em>Semigroup</em>.
+      *
+      * <h2>Example</h2>
+      * {{{
+      * case class MyError2(errors: List[String])
+      *
+      * given Semigroup[MyError2] with {
+      *   def combine(error1: MyError2, error2: MyError2): MyError2 =
+      *     MyError2(error1.errors ++ error2.errors)
+      * }
+      *
+      * val block: List[Int] raises MyError2 =
+      *   CatsRaise.zipOrAccumulateS({ 1 }, { 2 }, { 3 }, { 4 }, { 5 }, { 6 }, { 7 }, { 8 }) {
+      *     case (a, b, c, d, e, f, g, h) =>
+      *       List(a, b, c, d, e, f, g, h)
+      *   }
+      * val actual = Raise.fold(
+      *   block,
+      *   error => fail(s"An error occurred: $error"),
+      *   identity
+      * )
+      * actual should be(List(1, 2, 3, 4, 5, 6, 7, 8))
+      * }}}
+      *
+      * @param action1
+      *   Code block to run on type `A`
+      * @param action2
+      *   Code block to run on type `B`
+      * @param action3
+      *   Code block to run on type `C`
+      * @param action4
+      *   Code block to run on type `D`
+      * @param action5
+      *   Code block to run on type `E`
+      * @param action6
+      *   Code block to run on type `F`
+      * @param action7
+      *   Code block to run on type `G`
+      * @param action8
+      *   Code block to run on type `H`
+      * @param block
+      *   Function to run on the results of the code blocks
+      * @param r
+      *   The Raise context
+      * @tparam Error
+      *   The type of the logical error that can be raised by any code block. It must have a
+      *   [[Semigroup]] instance available
+      * @tparam A
+      *   The type of the result of the first code block
+      * @tparam B
+      *   The type of the result of the second code block
+      * @tparam C
+      *   The type of the result of the third code block
+      * @tparam D
+      *   The type of the result of the fourth code block
+      * @tparam E
+      *   The type of the result of the fifth code block
+      * @tparam F
+      *   The type of the result of the sixth code block
+      * @tparam G
+      *   The type of the result of the seventh code block
+      * @tparam H
+      *   The type of the result of the eighth code block
+      * @tparam I
+      *   The type of the result of the block function
+      * @return
+      *   The result of the block function
+      */
+  inline def zipOrAccumulateS[Error: Semigroup, A, B, C, D, E, F, G, H, I](
+      inline action1: Raise[Error] ?=> A,
+      inline action2: Raise[Error] ?=> B,
+      inline action3: Raise[Error] ?=> C,
+      inline action4: Raise[Error] ?=> D,
+      inline action5: Raise[Error] ?=> E,
+      inline action6: Raise[Error] ?=> F,
+      inline action7: Raise[Error] ?=> G,
+      inline action8: Raise[Error] ?=> H
+  )(inline block: (A, B, C, D, E, F, G, H) => I)(using r: Raise[Error]): I =
+    Raise.zipOrAccumulate(Semigroup[Error].combine)(
+      action1,
+      action2,
+      action3,
+      action4,
+      action5,
+      action6,
+      action7,
+      action8,
+      {}
+    ) { (a, b, c, d, e, f, g, h, _) =>
+      block(a, b, c, d, e, f, g, h)
+    }
+
+    /** Accumulate the errors from running `action1`, `action2`, `action3`, `action4`, `action5`,
+      * `action6`, and `action7`, or accumulate all the occurred errors using the
+      * [[Semigroup]] type class defined on the `Error` type. The tailing `S` in the name of the
+      * function stands for <em>Semigroup</em>.
+      *
+      * <h2>Example</h2>
+      * {{{
+      * case class MyError2(errors: List[String])
+      *
+      * given Semigroup[MyError2] with {
+      *   def combine(error1: MyError2, error2: MyError2): MyError2 =
+      *     MyError2(error1.errors ++ error2.errors)
+      * }
+      *
+      * val block: List[Int] raises MyError2 =
+      *   CatsRaise.zipOrAccumulateS({ 1 }, { 2 }, { 3 }, { 4 }, { 5 }, { 6 }, { 7 }) {
+      *     case (a, b, c, d, e, f, g) =>
+      *       List(a, b, c, d, e, f, g)
+      *   }
+      * val actual = Raise.fold(
+      *   block,
+      *   error => fail(s"An error occurred: $error"),
+      *   identity
+      * )
+      * actual should be(List(1, 2, 3, 4, 5, 6, 7))
+      * }}}
+      *
+      * @param action1
+      *   Code block to run on type `A`
+      * @param action2
+      *   Code block to run on type `B`
+      * @param action3
+      *   Code block to run on type `C`
+      * @param action4
+      *   Code block to run on type `D`
+      * @param action5
+      *   Code block to run on type `E`
+      * @param action6
+      *   Code block to run on type `F`
+      * @param action7
+      *   Code block to run on type `G`
+      * @param block
+      *   Function to run on the results of the code blocks
+      * @param r
+      *   The Raise context
+      * @tparam Error
+      *   The type of the logical error that can be raised by any code block. It must have a
+      *   [[Semigroup]] instance available
+      * @tparam A
+      *   The type of the result of the first code block
+      * @tparam B
+      *   The type of the result of the second code block
+      * @tparam C
+      *   The type of the result of the third code block
+      * @tparam D
+      *   The type of the result of the fourth code block
+      * @tparam E
+      *   The type of the result of the fifth code block
+      * @tparam F
+      *   The type of the result of the sixth code block
+      * @tparam G
+      *   The type of the result of the seventh code block
+      * @tparam H
+      *   The type of the result of the block function
+      * @return
+      *   The result of the block function
+      */
+  inline def zipOrAccumulateS[Error: Semigroup, A, B, C, D, E, F, G, H](
+      inline action1: Raise[Error] ?=> A,
+      inline action2: Raise[Error] ?=> B,
+      inline action3: Raise[Error] ?=> C,
+      inline action4: Raise[Error] ?=> D,
+      inline action5: Raise[Error] ?=> E,
+      inline action6: Raise[Error] ?=> F,
+      inline action7: Raise[Error] ?=> G
+  )(inline block: (A, B, C, D, E, F, G) => H)(using r: Raise[Error]): H =
+    Raise.zipOrAccumulate(Semigroup[Error].combine)(
+      action1,
+      action2,
+      action3,
+      action4,
+      action5,
+      action6,
+      action7,
+      {},
+      {}
+    ) { (a, b, c, d, e, f, g, _, _) =>
+      block(a, b, c, d, e, f, g)
+    }
 }

--- a/cats-raise4s/src/main/scala/in/rcard/raise4s/cats/CatsRaise.scala
+++ b/cats-raise4s/src/main/scala/in/rcard/raise4s/cats/CatsRaise.scala
@@ -291,9 +291,9 @@ object CatsRaise {
     }
 
     /** Accumulate the errors from running `action1`, `action2`, `action3`, `action4`, `action5`,
-      * `action6`, and `action7`, or accumulate all the occurred errors using the
-      * [[Semigroup]] type class defined on the `Error` type. The tailing `S` in the name of the
-      * function stands for <em>Semigroup</em>.
+      * `action6`, and `action7`, or accumulate all the occurred errors using the [[Semigroup]] type
+      * class defined on the `Error` type. The tailing `S` in the name of the function stands for
+      * <em>Semigroup</em>.
       *
       * <h2>Example</h2>
       * {{{
@@ -378,5 +378,377 @@ object CatsRaise {
       {}
     ) { (a, b, c, d, e, f, g, _, _) =>
       block(a, b, c, d, e, f, g)
+    }
+
+    /** Accumulate the errors from running `action1`, `action2`, `action3`, `action4`, `action5`,
+      * and `action6`, or accumulate all the occurred errors using the [[Semigroup]] type class
+      * defined on the `Error` type. The tailing `S` in the name of the function stands for
+      * <em>Semigroup</em>.
+      *
+      * <h2>Example</h2>
+      * {{{
+      * case class MyError2(errors: List[String])
+      *
+      * given Semigroup[MyError2] with {
+      *   def combine(error1: MyError2, error2: MyError2): MyError2 =
+      *     MyError2(error1.errors ++ error2.errors)
+      * }
+      *
+      * val block: List[Int] raises MyError2 =
+      *   CatsRaise.zipOrAccumulateS({ 1 }, { 2 }, { 3 }, { 4 }, { 5 }, { 6 }) {
+      *     case (a, b, c, d, e, f) =>
+      *       List(a, b, c, d, e, f)
+      *   }
+      * val actual = Raise.fold(
+      *   block,
+      *   error => fail(s"An error occurred: $error"),
+      *   identity
+      * )
+      * actual should be(List(1, 2, 3, 4, 5, 6))
+      * }}}
+      *
+      * @param action1
+      *   Code block to run on type `A`
+      * @param action2
+      *   Code block to run on type `B`
+      * @param action3
+      *   Code block to run on type `C`
+      * @param action4
+      *   Code block to run on type `D`
+      * @param action5
+      *   Code block to run on type `E`
+      * @param action6
+      *   Code block to run on type `F`
+      * @param block
+      *   Function to run on the results of the code blocks
+      * @param r
+      *   The Raise context
+      * @tparam Error
+      *   The type of the logical error that can be raised by any code block. It must have a
+      *   [[Semigroup]] instance available
+      * @tparam A
+      *   The type of the result of the first code block
+      * @tparam B
+      *   The type of the result of the second code block
+      * @tparam C
+      *   The type of the result of the third code block
+      * @tparam D
+      *   The type of the result of the fourth code block
+      * @tparam E
+      *   The type of the result of the fifth code block
+      * @tparam F
+      *   The type of the result of the sixth code block
+      * @tparam G
+      *   The type of the result of the block function
+      * @return
+      *   The result of the block function
+      */
+  inline def zipOrAccumulateS[Error: Semigroup, A, B, C, D, E, F, G](
+      inline action1: Raise[Error] ?=> A,
+      inline action2: Raise[Error] ?=> B,
+      inline action3: Raise[Error] ?=> C,
+      inline action4: Raise[Error] ?=> D,
+      inline action5: Raise[Error] ?=> E,
+      inline action6: Raise[Error] ?=> F
+  )(inline block: (A, B, C, D, E, F) => G)(using r: Raise[Error]): G =
+    Raise.zipOrAccumulate(Semigroup[Error].combine)(
+      action1,
+      action2,
+      action3,
+      action4,
+      action5,
+      action6,
+      {},
+      {},
+      {}
+    ) { (a, b, c, d, e, f, _, _, _) =>
+      block(a, b, c, d, e, f)
+    }
+
+    /** Accumulate the errors from running `action1`, `action2`, `action3`, `action4`, and
+      * `action5`, or accumulate all the occurred errors using the [[Semigroup]] type class defined
+      * on the `Error` type. The tailing `S` in the name of the function stands for
+      * <em>Semigroup</em>.
+      *
+      * <h2>Example</h2>
+      * {{{
+      * case class MyError2(errors: List[String])
+      *
+      * given Semigroup[MyError2] with {
+      *   def combine(error1: MyError2, error2: MyError2): MyError2 =
+      *     MyError2(error1.errors ++ error2.errors)
+      * }
+      *
+      * val block: List[Int] raises MyError2 =
+      *   CatsRaise.zipOrAccumulateS({ 1 }, { 2 }, { 3 }, { 4 }, { 5 }) {
+      *     case (a, b, c, d, e) =>
+      *       List(a, b, c, d, e)
+      *   }
+      * val actual = Raise.fold(
+      *   block,
+      *   error => fail(s"An error occurred: $error"),
+      *   identity
+      * )
+      * actual should be(List(1, 2, 3, 4, 5))
+      * }}}
+      *
+      * @param action1
+      *   Code block to run on type `A`
+      * @param action2
+      *   Code block to run on type `B`
+      * @param action3
+      *   Code block to run on type `C`
+      * @param action4
+      *   Code block to run on type `D`
+      * @param action5
+      *   Code block to run on type `E`
+      * @param block
+      *   Function to run on the results of the code blocks
+      * @param r
+      *   The Raise context
+      * @tparam Error
+      *   The type of the logical error that can be raised by any code block. It must have a
+      *   [[Semigroup]] instance available
+      * @tparam A
+      *   The type of the result of the first code block
+      * @tparam B
+      *   The type of the result of the second code block
+      * @tparam C
+      *   The type of the result of the third code block
+      * @tparam D
+      *   The type of the result of the fourth code block
+      * @tparam E
+      *   The type of the result of the fifth code block
+      * @tparam F
+      *   The type of the result of the block function
+      * @return
+      *   The result of the block function
+      */
+  inline def zipOrAccumulateS[Error: Semigroup, A, B, C, D, E, F](
+      inline action1: Raise[Error] ?=> A,
+      inline action2: Raise[Error] ?=> B,
+      inline action3: Raise[Error] ?=> C,
+      inline action4: Raise[Error] ?=> D,
+      inline action5: Raise[Error] ?=> E
+  )(inline block: (A, B, C, D, E) => F)(using r: Raise[Error]): F =
+    Raise.zipOrAccumulate(Semigroup[Error].combine)(
+      action1,
+      action2,
+      action3,
+      action4,
+      action5,
+      {},
+      {},
+      {},
+      {}
+    ) { (a, b, c, d, e, _, _, _, _) =>
+      block(a, b, c, d, e)
+    }
+
+  /** Accumulate the errors from running `action1`, `action2`, `action3`, and `action4`, or
+    * accumulate all the occurred errors using the [[Semigroup]] type class defined on the `Error`
+    * type. The tailing `S` in the name of the function stands for <em>Semigroup</em>.
+    *
+    * <h2>Example</h2>
+    * {{{
+    * case class MyError2(errors: List[String])
+    *
+    * given Semigroup[MyError2] with {
+    *   def combine(error1: MyError2, error2: MyError2): MyError2 =
+    *     MyError2(error1.errors ++ error2.errors)
+    * }
+    *
+    * val block: List[Int] raises MyError2 =
+    *   CatsRaise.zipOrAccumulateS({ 1 }, { 2 }, { 3 }, { 4 }) {
+    *     case (a, b, c, d) =>
+    *       List(a, b, c, d)
+    *   }
+    * val actual = Raise.fold(
+    *   block,
+    *   error => fail(s"An error occurred: $error"),
+    *   identity
+    * )
+    * actual should be(List(1, 2, 3, 4))
+    * }}}
+    *
+    * @param action1
+    *   Code block to run on type `A`
+    * @param action2
+    *   Code block to run on type `B`
+    * @param action3
+    *   Code block to run on type `C`
+    * @param action4
+    *   Code block to run on type `D`
+    * @param block
+    *   Function to run on the results of the code blocks
+    * @param r
+    *   The Raise context
+    * @tparam Error
+    *   The type of the logical error that can be raised by any code block. It must have a
+    *   [[Semigroup]] instance available
+    * @tparam A
+    *   The type of the result of the first code block
+    * @tparam B
+    *   The type of the result of the second code block
+    * @tparam C
+    *   The type of the result of the third code block
+    * @tparam D
+    *   The type of the result of the fourth code block
+    * @tparam E
+    *   The type of the result of the block function
+    * @return
+    *   The result of the block function
+    */
+  inline def zipOrAccumulateS[Error: Semigroup, A, B, C, D, E](
+      inline action1: Raise[Error] ?=> A,
+      inline action2: Raise[Error] ?=> B,
+      inline action3: Raise[Error] ?=> C,
+      inline action4: Raise[Error] ?=> D
+  )(inline block: (A, B, C, D) => E)(using r: Raise[Error]): E =
+    Raise.zipOrAccumulate(Semigroup[Error].combine)(
+      action1,
+      action2,
+      action3,
+      action4,
+      {},
+      {},
+      {},
+      {},
+      {}
+    ) { (a, b, c, d, _, _, _, _, _) =>
+      block(a, b, c, d)
+    }
+
+    /** Accumulate the errors from running `action1`, `action2`, and `action3`, or accumulate all
+      * the occurred errors using the [[Semigroup]] type class defined on the `Error` type. The
+      * tailing `S` in the name of the function stands for <em>Semigroup</em>.
+      *
+      * <h2>Example</h2>
+      * {{{
+      * case class MyError2(errors: List[String])
+      *
+      * given Semigroup[MyError2] with {
+      *   def combine(error1: MyError2, error2: MyError2): MyError2 =
+      *     MyError2(error1.errors ++ error2.errors)
+      * }
+      *
+      * val block: List[Int] raises MyError2 =
+      *   CatsRaise.zipOrAccumulateS({ 1 }, { 2 }, { 3 }) {
+      *     case (a, b, c) =>
+      *       List(a, b, c)
+      *   }
+      * val actual = Raise.fold(
+      *   block,
+      *   error => fail(s"An error occurred: $error"),
+      *   identity
+      * )
+      * actual should be(List(1, 2, 3))
+      * }}}
+      *
+      * @param action1
+      *   Code block to run on type `A`
+      * @param action2
+      *   Code block to run on type `B`
+      * @param action3
+      *   Code block to run on type `C`
+      * @param block
+      *   Function to run on the results of the code blocks
+      * @param r
+      *   The Raise context
+      * @tparam Error
+      *   The type of the logical error that can be raised by any code block. It must have a
+      *   [[Semigroup]] instance available
+      * @tparam A
+      *   The type of the result of the first code block
+      * @tparam B
+      *   The type of the result of the second code block
+      * @tparam C
+      *   The type of the result of the third code block
+      * @tparam D
+      *   The type of the result of the block function
+      * @return
+      *   The result of the block function
+      */
+  inline def zipOrAccumulateS[Error: Semigroup, A, B, C, D](
+      inline action1: Raise[Error] ?=> A,
+      inline action2: Raise[Error] ?=> B,
+      inline action3: Raise[Error] ?=> C
+  )(inline block: (A, B, C) => D)(using r: Raise[Error]): D =
+    Raise.zipOrAccumulate(Semigroup[Error].combine)(
+      action1,
+      action2,
+      action3,
+      {},
+      {},
+      {},
+      {},
+      {},
+      {}
+    ) { (a, b, c, _, _, _, _, _, _) =>
+      block(a, b, c)
+    }
+
+    /** Accumulate the errors from running `action1`, and `action2`, or accumulate all the occurred
+      * errors using the [[Semigroup]] type class defined on the `Error` type. The tailing `S` in
+      * the name of the function stands for <em>Semigroup</em>.
+      *
+      * <h2>Example</h2>
+      * {{{
+      * case class MyError2(errors: List[String])
+      *
+      * given Semigroup[MyError2] with {
+      *   def combine(error1: MyError2, error2: MyError2): MyError2 =
+      *     MyError2(error1.errors ++ error2.errors)
+      * }
+      *
+      * val block: List[Int] raises MyError2 =
+      *   CatsRaise.zipOrAccumulateS({ 1 }, { 2 }) {
+      *     case (a, b) =>
+      *       List(a, b)
+      *   }
+      * val actual = Raise.fold(
+      *   block,
+      *   error => fail(s"An error occurred: $error"),
+      *   identity
+      * )
+      * actual should be(List(1, 2))
+      * }}}
+      *
+      * @param action1
+      *   Code block to run on type `A`
+      * @param action2
+      *   Code block to run on type `B`
+      * @param block
+      *   Function to run on the results of the code blocks
+      * @param r
+      *   The Raise context
+      * @tparam Error
+      *   The type of the logical error that can be raised by any code block. It must have a
+      *   [[Semigroup]] instance available
+      * @tparam A
+      *   The type of the result of the first code block
+      * @tparam B
+      *   The type of the result of the second code block
+      * @tparam C
+      *   The type of the result of the block function
+      * @return
+      *   The result of the block function
+      */
+  inline def zipOrAccumulateS[Error: Semigroup, A, B, C](
+      inline action1: Raise[Error] ?=> A,
+      inline action2: Raise[Error] ?=> B
+  )(inline block: (A, B) => C)(using r: Raise[Error]): C =
+    Raise.zipOrAccumulate(Semigroup[Error].combine)(
+      action1,
+      action2,
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {}
+    ) { (a, b, _, _, _, _, _, _, _) =>
+      block(a, b)
     }
 }

--- a/cats-raise4s/src/test/scala/in/rcard/raise4s/cats/CatsRaiseSpec.scala
+++ b/cats-raise4s/src/test/scala/in/rcard/raise4s/cats/CatsRaiseSpec.scala
@@ -13,7 +13,7 @@ class CatsRaiseSpec extends AnyFlatSpec with Matchers {
     def combine(error1: MyError2, error2: MyError2): MyError2 =
       MyError2(error1.errors ++ error2.errors)
   }
-  
+
   "mapOrAccumulate on Semigroup[Error]" should "map all the element of the iterable" in {
     val block: List[Int] raises MyError2 =
       CatsRaise.mapOrAccumulateS(List(1, 2, 3, 4, 5)) { value1 =>
@@ -49,9 +49,10 @@ class CatsRaiseSpec extends AnyFlatSpec with Matchers {
   }
 
   "mapOrAccumulate to NonEmptyList" should "map all the element of the iterable" in {
-    val block: List[Int] raises NonEmptyList[String] = CatsRaise.mapOrAccumulate(List(1, 2, 3, 4, 5)) {
-      value1 => value1 + 1
-    }
+    val block: List[Int] raises NonEmptyList[String] =
+      CatsRaise.mapOrAccumulate(List(1, 2, 3, 4, 5)) { value1 =>
+        value1 + 1
+      }
 
     val actual = Raise.fold(
       block,
@@ -63,13 +64,14 @@ class CatsRaiseSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "accumulate all the errors" in {
-    val block: List[Int] raises NonEmptyList[String] = CatsRaise.mapOrAccumulate(List(1, 2, 3, 4, 5)) { value =>
-      if (value % 2 == 0) {
-        Raise.raise(value.toString)
-      } else {
-        value
+    val block: List[Int] raises NonEmptyList[String] =
+      CatsRaise.mapOrAccumulate(List(1, 2, 3, 4, 5)) { value =>
+        if (value % 2 == 0) {
+          Raise.raise(value.toString)
+        } else {
+          value
+        }
       }
-    }
 
     val actual = Raise.fold(
       block,
@@ -78,5 +80,55 @@ class CatsRaiseSpec extends AnyFlatSpec with Matchers {
     )
 
     actual shouldBe NonEmptyList.of("2", "4")
+  }
+
+  "zipOrAccumulateS with combine" should "zip 9 elements" in {
+    val block: List[Int] raises MyError2 =
+      CatsRaise.zipOrAccumulateS({ 1 }, { 2 }, { 3 }, { 4 }, { 5 }, { 6 }, { 7 }, { 8 }, { 9 }) {
+        case (a, b, c, d, e, f, g, h, i) =>
+          List(a, b, c, d, e, f, g, h, i)
+      }
+
+    val actual = Raise.fold(
+      block,
+      error => fail(s"An error occurred: $error"),
+      identity
+    )
+
+    actual should be(List(1, 2, 3, 4, 5, 6, 7, 8, 9))
+  }
+
+  it should "accumulate errors combining them" in {
+    val block: List[Int] raises MyError2 = CatsRaise.zipOrAccumulateS(
+      {
+        1
+      }, {
+        if (true) Raise.raise(MyError2(List("2"))) else 2
+      }, {
+        3
+      }, {
+        if (true) Raise.raise(MyError2(List("4"))) else 4
+      }, {
+        5
+      }, {
+        if (true) Raise.raise(MyError2(List("6"))) else 6
+      }, {
+        7
+      }, {
+        if (true) Raise.raise(MyError2(List("8"))) else 8
+      }, {
+        9
+      }
+    ) { case (a, b, c, d, e, f, g, h, i) =>
+      List(a, b, c, d, e, f, g, h, i)
+    }
+
+    val actual = Raise.fold(
+      block,
+      identity,
+      identity
+    )
+
+    actual should be(MyError2(List("2", "4", "6", "8")))
   }
 }

--- a/cats-raise4s/src/test/scala/in/rcard/raise4s/cats/CatsRaiseSpec.scala
+++ b/cats-raise4s/src/test/scala/in/rcard/raise4s/cats/CatsRaiseSpec.scala
@@ -100,25 +100,15 @@ class CatsRaiseSpec extends AnyFlatSpec with Matchers {
 
   it should "accumulate errors combining them" in {
     val block: List[Int] raises MyError2 = CatsRaise.zipOrAccumulateS(
-      {
-        1
-      }, {
-        if (true) Raise.raise(MyError2(List("2"))) else 2
-      }, {
-        3
-      }, {
-        if (true) Raise.raise(MyError2(List("4"))) else 4
-      }, {
-        5
-      }, {
-        if (true) Raise.raise(MyError2(List("6"))) else 6
-      }, {
-        7
-      }, {
-        if (true) Raise.raise(MyError2(List("8"))) else 8
-      }, {
-        9
-      }
+      { 1 },
+      { if (true) Raise.raise(MyError2(List("2"))) else 2 },
+      { 3 },
+      { if (true) Raise.raise(MyError2(List("4"))) else 4 },
+      { 5},
+      { if (true) Raise.raise(MyError2(List("6"))) else 6 },
+      { 7 },
+      { if (true) Raise.raise(MyError2(List("8"))) else 8 },
+      { 9 }
     ) { case (a, b, c, d, e, f, g, h, i) =>
       List(a, b, c, d, e, f, g, h, i)
     }


### PR DESCRIPTION
Closes #50 