### PR TITLE
Add a new strategy to map logical typed error without using the `withError` function

### DIFF
--- a/core/src/main/scala/in/rcard/raise4s/Strategies.scala
+++ b/core/src/main/scala/in/rcard/raise4s/Strategies.scala
@@ -14,10 +14,37 @@ object Strategies {
 
   type anyRaised = Raise[Any]
 
-  infix type mapTo[EO, EN] = MapError[EO, EN]
-  trait MapError[EO, EN] extends Raise[EO] {
-    def map(error: EO): EN
+  infix type mapTo[From, To] = MapError[From, To]
 
-    def raise(error: EO): Nothing = throw Raised(map(error))
+  /** A strategy that allow to map an error to another one. As a strategy, it should be used as a
+    * `given` instance. Its behavior is comparable to the [[Raise.withError]] method.
+    *
+    * <h2>Example</h2>
+    * {{{
+    * val finalLambda: String raises Int = {
+    *   given MapError[String, Int] = error => error.length
+    *   raise("Oops!")
+    * }
+    *
+    * val result: Int | String = Raise.run(finalLambda)
+    * result shouldBe 5
+    * }}}
+    *
+    * @tparam From
+    *   The original error type
+    * @tparam To
+    *   The error type to map to
+    */
+  trait MapError[From, To] extends Raise[From] {
+
+    /** Maps an error to another one.
+      * @param error
+      *   The error to map
+      * @return
+      *   The mapped error
+      */
+    def map(error: From): To
+
+    def raise(error: From): Nothing = throw Raised(map(error))
   }
 }

--- a/core/src/main/scala/in/rcard/raise4s/Strategies.scala
+++ b/core/src/main/scala/in/rcard/raise4s/Strategies.scala
@@ -2,13 +2,22 @@ package in.rcard.raise4s
 
 object Strategies {
 
-  /**
-   * An exception that make it easy to throw a logic-typed error if the error is not already a [[Throwable]].
-   *
-   * @param error The logic-typed error to raise
-   * @tparam E The type of the logic-typed error
-   */
+  /** An exception that make it easy to throw a logic-typed error if the error is not already a
+    * [[Throwable]].
+    *
+    * @param error
+    *   The logic-typed error to raise
+    * @tparam E
+    *   The type of the logic-typed error
+    */
   class UnsafeRaiseException[E](val error: E) extends Exception()
-  
+
   type anyRaised = Raise[Any]
+
+  infix type mapTo[EO, EN] = MapError[EO, EN]
+  trait MapError[EO, EN] extends Raise[EO] {
+    def map(error: EO): EN
+
+    def raise(error: EO): Nothing = throw Raised(map(error))
+  }
 }

--- a/core/src/test/scala/in/rcard/raise4s/StrategiesSpec.scala
+++ b/core/src/test/scala/in/rcard/raise4s/StrategiesSpec.scala
@@ -1,6 +1,6 @@
 package in.rcard.raise4s
 
-import in.rcard.raise4s.Strategies.anyRaised
+import in.rcard.raise4s.Strategies.{MapError, anyRaised}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -8,10 +8,21 @@ class StrategiesSpec extends AnyFlatSpec with Matchers {
 
   "anyRaised" should "allow defining a strategy that throw any given error" in {
     val lambdaRaisingError: Int raises String = Raise.raise("Oops!")
-    given anyRaised = error => throw new RuntimeException(error.toString)
+    given anyRaised                           = error => throw new RuntimeException(error.toString)
     val ex = intercept[RuntimeException] {
       lambdaRaisingError
     }
     ex.getMessage shouldBe "Oops!"
+  }
+
+  "MapError" should "allow defining a strategy that map an error to another one" in {
+    given MapError[String, Int]               = error => error.length
+    val lambdaRaisingError: Int raises String = Raise.raise("Oops!")
+    val finalLambda: String raises Int = {
+      val r: Int = lambdaRaisingError
+      r.toString
+    }
+    val result: Int | String = Raise.run(finalLambda)
+    result shouldBe 5
   }
 }

--- a/core/src/test/scala/in/rcard/raise4s/StrategiesSpec.scala
+++ b/core/src/test/scala/in/rcard/raise4s/StrategiesSpec.scala
@@ -1,5 +1,6 @@
 package in.rcard.raise4s
 
+import in.rcard.raise4s.Raise.raise
 import in.rcard.raise4s.Strategies.{MapError, anyRaised}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -7,7 +8,7 @@ import org.scalatest.matchers.should.Matchers
 class StrategiesSpec extends AnyFlatSpec with Matchers {
 
   "anyRaised" should "allow defining a strategy that throw any given error" in {
-    val lambdaRaisingError: Int raises String = Raise.raise("Oops!")
+    val lambdaRaisingError: Int raises String = raise("Oops!")
     given anyRaised                           = error => throw new RuntimeException(error.toString)
     val ex = intercept[RuntimeException] {
       lambdaRaisingError
@@ -15,14 +16,27 @@ class StrategiesSpec extends AnyFlatSpec with Matchers {
     ex.getMessage shouldBe "Oops!"
   }
 
+  it should "return the happy path value if no error is raised" in {
+    val lambdaRaisingError: String raises Int = "Hello"
+    given anyRaised                           = error => throw new RuntimeException(error.toString)
+    lambdaRaisingError shouldBe "Hello"
+  }
+
   "MapError" should "allow defining a strategy that map an error to another one" in {
-    given MapError[String, Int]               = error => error.length
-    val lambdaRaisingError: Int raises String = Raise.raise("Oops!")
     val finalLambda: String raises Int = {
-      val r: Int = lambdaRaisingError
-      r.toString
+      given MapError[String, Int] = error => error.length
+      raise("Oops!")
     }
     val result: Int | String = Raise.run(finalLambda)
     result shouldBe 5
+  }
+
+  it should "return the happy path value if no error is raised" in {
+    val finalLambda: String raises Int = {
+      given MapError[String, Int] = error => error.length
+      "Hello"
+    }
+    val result: Int | String = Raise.run(finalLambda)
+    result shouldBe "Hello"
   }
 }


### PR DESCRIPTION
Closes #71 