### PR TITLE
Fix CCE upon nesting different Raise instances

### DIFF
--- a/core/src/test/scala/in/rcard/raise4s/RaiseSpec.scala
+++ b/core/src/test/scala/in/rcard/raise4s/RaiseSpec.scala
@@ -2,6 +2,7 @@ package in.rcard.raise4s
 
 import in.rcard.raise4s.Raise.catching
 import in.rcard.raise4s.Strategies.RecoverWith
+import in.rcard.raise4s.Bind.value
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -190,5 +191,31 @@ class RaiseSpec extends AnyFlatSpec with Matchers {
     }
 
     actual should be(Right(43))
+  }
+
+  it should "nest successfully with differently-typed instances" in {
+    val actual = Raise.either {
+      Raise.option {
+        Raise.raise("error")
+      }
+    }
+
+    actual should be(Left("error"))
+  }
+
+  it should "allow effect encapsulation" in {
+    def toIntOrDefault(block: () => String): Int = {
+      Raise.option {
+        val res: String = block()
+        res.toIntOption.value
+      }.getOrElse(42)
+    }
+    val actual = Raise.either {
+      toIntOrDefault { () =>
+        Raise.raise("error")
+      }
+    }
+
+    actual should be(Left("error"))
   }
 }

--- a/core/src/test/scala/in/rcard/raise4s/StrategiesSpec.scala
+++ b/core/src/test/scala/in/rcard/raise4s/StrategiesSpec.scala
@@ -2,6 +2,7 @@ package in.rcard.raise4s
 
 import in.rcard.raise4s.Raise.{raise, traced}
 import in.rcard.raise4s.Strategies.{MapError, TraceWith, anyRaised}
+import in.rcard.raise4s.Strategies.MapError.mappedRaise
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -29,6 +30,15 @@ class StrategiesSpec extends AnyFlatSpec with Matchers {
     }
     val result: Int | String = Raise.run(finalLambda)
     result shouldBe 5
+  }
+
+  "MapError" should "allow raising the original error type" in {
+    val finalLambda: String raises Int = {
+      given MapError[String, Int] = error => error.length
+      raise(42)
+    }
+    val result: Int | String = Raise.run(finalLambda)
+    result shouldBe 42
   }
 
   it should "return the happy path value if no error is raised" in {


### PR DESCRIPTION
This is implemented by tagging every Exception with the `DefaultRaise` instance that created it. Thus, the exception is only caught by the apt Raise handler.